### PR TITLE
feat(nix): make vi context-aware

### DIFF
--- a/nix/modules/home/core.nix
+++ b/nix/modules/home/core.nix
@@ -383,6 +383,18 @@
       };
 
       initContent = ''
+        vi() {
+          if [[ -n "$VSCODE_INJECTION" || "$TERM_PROGRAM" == "vscode" ]]; then
+            command code -r "$@"
+          else
+            command nvim "$@"
+          fi
+        }
+
+        vim() {
+          vi "$@"
+        }
+
         # vi mode keybindings
         bindkey -v
 


### PR DESCRIPTION
## Summary

- make `vi` and `vim` open files in the current VS Code window from integrated terminals
- use Neovim from other zsh shells on every host

## Why

The existing Neovim aliases do not reliably override the system Vim on macOS, and VS Code integrated terminals should reuse the active editor window.

## Impact

Editor commands now select VS Code or Neovim according to the terminal environment while preserving all command arguments.

## Validation

- `nix run nixpkgs#alejandra -- .`
- `nix flake check`
- `statix check`
- `deadnix --fail`
