### PR TITLE
feat: add codex compound alias

### DIFF
--- a/nix/modules/home/core.nix
+++ b/nix/modules/home/core.nix
@@ -344,6 +344,7 @@
 
       shellAliases = {
         cat = "bat --pager=never";
+        codex-compound = "CODEX_HOME=~/.codex-compound codex";
 
         cdc = "cd ~/Code";
         cdh = "cd ~/Code/github.com/craigjperry2/home-network/";


### PR DESCRIPTION
Adds a Zsh alias that launches Codex with an isolated CODEX_HOME at ~/.codex-compound.\n\nValidated with Alejandra, nix flake check, statix, and deadnix.