### PR TITLE
feat(nix): deps version bump

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -3,11 +3,11 @@
     "arthur-ficial-tap": {
       "flake": false,
       "locked": {
-        "lastModified": 1783612372,
-        "narHash": "sha256-3fxPt9y1ab1370RfxxiuS/zb6PxKD3p+LZQbJ/jfgOo=",
+        "lastModified": 1784708312,
+        "narHash": "sha256-QusF2Kr9A/sTKs2iDdvLIjBSzAhy2iCqh3IaUf+99d4=",
         "owner": "arthur-ficial",
         "repo": "homebrew-tap",
-        "rev": "728ad36f9892e70ec3910327bbcd0b02460ed35e",
+        "rev": "494ad37930112b80d4eb3c1ceb5f0913bf431f0e",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1783783917,
-        "narHash": "sha256-JVlVtaMt1EBbVrRsg5+D2IUw7BzZZVfQW49tQxZpICM=",
+        "lastModified": 1784741555,
+        "narHash": "sha256-3E+39S2y/HuK9z7FKJ0AQKW2ymMo9zixOx+41ybtjV0=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "34c40c18ffa2029b611b61c73273e32c003d0842",
+        "rev": "c010c96b2366b30b73e3f0879dfc9b45ce79988c",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783740085,
-        "narHash": "sha256-qajyHfZY29G2oEQk+uHxmsJcRoBUBXP9maTpFlwP/dI=",
+        "lastModified": 1784350909,
+        "narHash": "sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE+KzCrM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3cd22efe6471dc7365c822bd9ad73a21e55f38fb",
+        "rev": "4ce190229c73d44536caa7072f6308fb2d8feeb3",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1783784313,
-        "narHash": "sha256-eXe45kcAni0zQEc6Al9cMtHWT4BX7HRm6thIgKzkyTU=",
+        "lastModified": 1784747238,
+        "narHash": "sha256-R7OPlO1Appu+tJoI4332eoTkRRXIAp9Uzq0xyFHpFDI=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "db6babe9617a8df20e4bf1f2d8c2507e44f06add",
+        "rev": "86915776b183156103902ed4d5d71cbc4d762213",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1783784518,
-        "narHash": "sha256-PrkX3SweV5Qkm5iOVdImY87Of+MGF7ABKwWp2DTeWGw=",
+        "lastModified": 1784747439,
+        "narHash": "sha256-Uzv2CM8BlLHWBTOUAuiZlQ1GhgwiiwichIkyijeb8uw=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "7830ef37d12c334addc40696a30136267bfdbd21",
+        "rev": "e12f51ed47b658206b716e5bab08bbb7debb1846",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781389246,
-        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "lastModified": 1784159664,
+        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1783707519,
-        "narHash": "sha256-VJ+eK/EB7aIZ246bXjkYalr4YWQAtHRJeh15Qw2LxUs=",
+        "lastModified": 1784517550,
+        "narHash": "sha256-uH9LkreZXkpZXD0QOXBkQWnAHhlVuT0wUABFw7AN9BU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2b35450a66cf6ee8492099a6eb1903796965d32d",
+        "rev": "fca2dbd4c00c3063235e56bb91758e24fc67b7b8",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1783522502,
-        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -192,11 +192,11 @@
     "whatcable-tap": {
       "flake": false,
       "locked": {
-        "lastModified": 1783714781,
-        "narHash": "sha256-o+b0IVdTcAvA4BGRcpWgfLEXmxpVVxR+DTWxb/5DwDA=",
+        "lastModified": 1784556477,
+        "narHash": "sha256-dMDx18hN2JvrU3ubt9ODdHhnKkk9dNYiiwLXaUdH7aM=",
         "owner": "darrylmorley",
         "repo": "homebrew-whatcable",
-        "rev": "99e28554d7b361d77fdf307d7be607cd63b1bdd1",
+        "rev": "a85877286b820d73249aabec3434e7412f62045d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update Nix flake lock inputs via nix flake update.
- Bump nixpkgs, nix-darwin, home-manager, Homebrew sources, and Homebrew taps.

## Validation
- nix run nixpkgs#alejandra -- .
- nix flake check
- statix check
- deadnix --fail
