### PR TITLE
feat(nix): deps version bump

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784965343,
-        "narHash": "sha256-hropwB+0KUXoFhAtAaHo5TefpJll6l2AZ46cqDDeFbI=",
+        "lastModified": 1785225335,
+        "narHash": "sha256-xzUNPgjfG06GvFNiZq+68euMeP05xydLwSv1cuS8Gq4=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "60fec0afe78d223e3259e862233649d00bf1d634",
+        "rev": "ab4c80d1e6524389fb4ccc05744e9e617ef363c4",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     "arthur-ficial-tap": {
       "flake": false,
       "locked": {
-        "lastModified": 1784708312,
-        "narHash": "sha256-QusF2Kr9A/sTKs2iDdvLIjBSzAhy2iCqh3IaUf+99d4=",
+        "lastModified": 1785265334,
+        "narHash": "sha256-NF0FRRFlqqqBXbTmqitL4tVGcqhYYLhHAlHbcOT4hJI=",
         "owner": "arthur-ficial",
         "repo": "homebrew-tap",
-        "rev": "494ad37930112b80d4eb3c1ceb5f0913bf431f0e",
+        "rev": "a01ac7a3582cb50b1e2b3c39793461b899c88c8c",
         "type": "github"
       },
       "original": {
@@ -40,11 +40,11 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784741555,
-        "narHash": "sha256-3E+39S2y/HuK9z7FKJ0AQKW2ymMo9zixOx+41ybtjV0=",
+        "lastModified": 1785342880,
+        "narHash": "sha256-fPVqL4j4ZCjHcfy4WNVsCWSfyP7t6vm8nU7WjuOiwEI=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "c010c96b2366b30b73e3f0879dfc9b45ce79988c",
+        "rev": "9faee54a54d8e5e299c258687d03e2d4b5b3310e",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784350909,
-        "narHash": "sha256-ZWyzLbS1yKUTeFJLmdVuWNnHttL333/ldJbEE+KzCrM=",
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ce190229c73d44536caa7072f6308fb2d8feeb3",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1784747238,
-        "narHash": "sha256-R7OPlO1Appu+tJoI4332eoTkRRXIAp9Uzq0xyFHpFDI=",
+        "lastModified": 1785343822,
+        "narHash": "sha256-/bvKus1ql2UJBzPaKtRl+tWr0i/Vde9jtmjjwMx4XYc=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "86915776b183156103902ed4d5d71cbc4d762213",
+        "rev": "6b2ffd660fbd9bf00544dbc0cf1f86f93902f686",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1784747439,
-        "narHash": "sha256-Uzv2CM8BlLHWBTOUAuiZlQ1GhgwiiwichIkyijeb8uw=",
+        "lastModified": 1785343845,
+        "narHash": "sha256-iFLBmvyXzOOeqoYsReBlJb4vTdZCJ2hocAszaAcApJY=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "e12f51ed47b658206b716e5bab08bbb7debb1846",
+        "rev": "4b1e0f89a1e2a381fee0391879c8b63601c2202b",
         "type": "github"
       },
       "original": {
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784159664,
-        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
+        "lastModified": 1784906761,
+        "narHash": "sha256-2v0H8+Ert+xbm0oliHblXTPPczuKiibBUBvRax59kxg=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
+        "rev": "60623ec512406261f553d24033c8a0c53fd0b7f2",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784432872,
-        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
@@ -183,11 +183,11 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1784517550,
-        "narHash": "sha256-uH9LkreZXkpZXD0QOXBkQWnAHhlVuT0wUABFw7AN9BU=",
+        "lastModified": 1785067121,
+        "narHash": "sha256-rdJdWxAcg5fnntU4DjPivPdVEN4F+VJavw+UWpEMeUI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fca2dbd4c00c3063235e56bb91758e24fc67b7b8",
+        "rev": "329c3d2af6d1b618705150ea39f72c15eb4e613e",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1785090369,
+        "narHash": "sha256-m0pDuRJG7EDo9ri+4Ksu83VsI+PlxNC9lNBfydejce4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "624af665418d3c65d544145b4d34ad696439570e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update Nix flake lock inputs via nix flake update.
- Bump nixpkgs, nix-darwin, home-manager, Homebrew sources, and Homebrew taps.

## Validation
- nix run nixpkgs#alejandra -- .
- nix flake check
- statix check
- deadnix --fail
